### PR TITLE
feat: add ad-detecting media player sample

### DIFF
--- a/AdDetector/AdDetector.csproj
+++ b/AdDetector/AdDetector.csproj
@@ -2,6 +2,8 @@
 
   <ItemGroup>
     <PackageReference Include="SoundFingerprinting.Emy" Version="12.3.0" />
+    <PackageReference Include="LibVLCSharp" Version="3.8.2" />
+    <PackageReference Include="LibVLCSharp.Native" Version="3.8.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/AdDetector/Program.cs
+++ b/AdDetector/Program.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Collections.Generic;
 using SoundFingerprinting;              // TrackInfo, builders
 using SoundFingerprinting.Audio;        // IAudioService
 using SoundFingerprinting.Emy;          // FFmpegAudioService
@@ -10,19 +11,19 @@ using SoundFingerprinting.Data;
 using SoundFingerprinting.InMemory;
 using SoundFingerprinting.Query;        // AVQueryResult, ResultEntry
 using FFmpeg.AutoGen.Bindings.DynamicallyLoaded;  // dynamic loader
-using SoundFingerprinting.Strides;   
+using SoundFingerprinting.Strides;
+using LibVLCSharp.Shared;            // media playback
 
 internal class Program
 {
-
     /* --------------------------------------------------------------
        Project-root-relative folders
     -------------------------------------------------------------- */
     private static string AdsDir =>
         "C:/small_data/ads";
 
-    private static string AudioDir =>
-        "C:/small_data/audio";
+    private static string FingerprintsDir =>
+        "C:/small_data/fingerprints"; // where hashes are stored between runs
 
     /* --------------------------------------------------------------
        Initialise FFmpeg once and return the decoder
@@ -40,34 +41,44 @@ internal class Program
         return new FFmpegAudioService();
     }
 
-    /* -------------------------------------------------------------- */
-    private static readonly IModelService model = new InMemoryModelService();
-
     private static async Task Main()
     {
         Console.OutputEncoding = System.Text.Encoding.UTF8;
-        await IndexAdsAsync();
-        await ScanAudioAsync();
+        Core.Initialize();
+
+        Console.WriteLine("1) Index ads\n2) Detect media");
+        Console.Write("Select option: ");
+        var option = Console.ReadLine();
+        switch (option)
+        {
+            case "1":
+                await IndexAdsAsync();
+                break;
+            case "2":
+                await DetectAsync();
+                break;
+            default:
+                Console.WriteLine("Unknown option");
+                break;
+        }
     }
 
     private static async Task IndexAdsAsync()
     {
-        int secondsToAnalyze = 2; // number of seconds to analyze from query file
-        int startAtSecond = 0; // start at the begining
+        var model = new InMemoryModelService();
+
         foreach (var file in Directory.GetFiles(AdsDir, "*.*",
                                                 SearchOption.AllDirectories))
         {
             var track = new TrackInfo(Guid.NewGuid().ToString(),
                                       Path.GetFileNameWithoutExtension(file),
                                       "Ad");
-
-        
             var hashes = await FingerprintCommandBuilder.Instance
                 .BuildFingerprintCommand()
-                .From(file, secondsToAnalyze, startAtSecond)
+                .From(file)
                 .WithFingerprintConfig(config =>
                 {
-                    config.Audio.SampleRate = 5512; // Set directly if available
+                    config.Audio.SampleRate = 5512;
                     config.Audio.Stride = new IncrementalStaticStride(64);
                     return config;
                 })
@@ -77,36 +88,119 @@ internal class Program
             model.Insert(track, hashes);
             Console.WriteLine($"   Indexed {track.Title}");
             Console.WriteLine($"   {hashes.Count} hashes generated.");
-            // Console.WriteLine($"   {hashes.Max(h => h.Confidence):P2} max confidence.");
-            // Console.WriteLine($"   {hashes.Min(h => h.Confidence):P2} min confidence.");
-            Console.WriteLine($"   {hashes}");
         }
 
-        Console.WriteLine($"✓ {model.GetTrackIds().Count()} ad(s) ready.\n");
+        Directory.CreateDirectory(FingerprintsDir);
+        model.Snapshot(FingerprintsDir);
+        Console.WriteLine($"✓ {model.GetTrackIds().Count()} ad(s) ready and stored.\n");
     }
 
-    private static async Task ScanAudioAsync()
+    private static async Task DetectAsync()
     {
-        Console.WriteLine("→ Scanning content …");
-        // int secondsToAnalyze = 1000; // number of seconds to analyze from query file
-        // int startAtSecond = 0; // start at the begining
-        foreach (var file in Directory.GetFiles(AudioDir, "*.*",
-                                                SearchOption.AllDirectories))
+        if (!Directory.Exists(FingerprintsDir))
         {
-            AVQueryResult queryResult = await QueryCommandBuilder.Instance
-                                          .BuildQueryCommand()
-                                        //   .From(file, secondsToAnalyze, startAtSecond)
-                                          .From(file)
-                                          .UsingServices(model, audio)
-                                          .Query();
-
-            var hits = queryResult.Audio?.ResultEntries ?? Enumerable.Empty<ResultEntry>();
-
-            foreach (var hit in hits.Where(h => h.Confidence >= 0.20))
-            {
-                TimeSpan when = TimeSpan.FromSeconds(hit.QueryMatchStartsAt);
-                Console.WriteLine($"{Path.GetFileName(file)}  →  {hit.Track.Title} @ {when}");
-            }
+            Console.WriteLine("No fingerprints found. Run indexing first.");
+            return;
         }
+
+        var model = new InMemoryModelService(FingerprintsDir);
+
+        Console.WriteLine("Select detection mode:\n1) Audio file\n2) Video playback");
+        Console.Write("Mode: ");
+        var mode = Console.ReadLine();
+
+        Console.Write("Path to media file: ");
+        var file = (Console.ReadLine() ?? string.Empty).Trim('"');
+        if (!File.Exists(file))
+        {
+            Console.WriteLine("File not found");
+            return;
+        }
+
+        switch (mode)
+        {
+            case "1":
+                await DetectAudioAsync(model, file);
+                break;
+            case "2":
+                await DetectVideoAsync(model, file);
+                break;
+            default:
+                Console.WriteLine("Unknown mode");
+                break;
+        }
+    }
+
+    private static async Task DetectAudioAsync(IModelService model, string file)
+    {
+        AVQueryResult queryResult = await QueryCommandBuilder.Instance
+            .BuildQueryCommand()
+            .From(file)
+            .UsingServices(model, audio)
+            .Query();
+
+        var hits = queryResult.Audio?.ResultEntries
+            ?.Where(h => h.Confidence >= 0.20) ?? Enumerable.Empty<ResultEntry>();
+
+        if (!hits.Any())
+        {
+            Console.WriteLine("No match found.");
+            return;
+        }
+
+        foreach (var hit in hits)
+        {
+            var duration = TimeSpan.FromSeconds(hit.Track.Length);
+            Console.WriteLine($"Match: {hit.Track.Title} - {duration:mm\\:ss}");
+        }
+    }
+
+    private static async Task DetectVideoAsync(IModelService model, string file)
+    {
+        AVQueryResult queryResult = await QueryCommandBuilder.Instance
+            .BuildQueryCommand()
+            .From(file)
+            .UsingServices(model, audio)
+            .Query();
+
+        var hits = queryResult.Audio?.ResultEntries ?? Enumerable.Empty<ResultEntry>();
+        await PlayWithNotificationsAsync(file, hits);
+    }
+
+    private static async Task PlayWithNotificationsAsync(string file, IEnumerable<ResultEntry> hits)
+    {
+        using var libVLC = new LibVLC();
+        using var media = new Media(libVLC, file, FromType.FromPath);
+        using var player = new MediaPlayer(libVLC);
+        player.Play(media);
+
+        var playbackStart = DateTime.UtcNow;
+
+        foreach (var hit in hits.Where(h => h.Confidence >= 0.20))
+        {
+            _ = Task.Run(async () =>
+            {
+                var delay = TimeSpan.FromSeconds(hit.QueryMatchStartsAt);
+                var wait = delay - (DateTime.UtcNow - playbackStart);
+                if (wait > TimeSpan.Zero)
+                {
+                    await Task.Delay(wait);
+                }
+
+                var duration = TimeSpan.FromSeconds(hit.Track.Length);
+                player.SetMarqueeString(MediaPlayerMarqueeOption.Text,
+                    $"{hit.Track.Title} - {duration:mm\\:ss}");
+                player.SetMarqueeInt(MediaPlayerMarqueeOption.Timeout,
+                    (int)duration.TotalMilliseconds);
+                player.SetMarqueeInt(MediaPlayerMarqueeOption.Size, 30);
+                player.SetMarqueeInt(MediaPlayerMarqueeOption.Position,
+                    (int)MediaPlayerMarqueePosition.Top);
+                player.SetMarqueeInt(MediaPlayerMarqueeOption.Enable, 1);
+            });
+        }
+
+        var tcs = new TaskCompletionSource();
+        player.EndReached += (_, _) => tcs.SetResult();
+        await tcs.Task;
     }
 }


### PR DESCRIPTION
## Summary
- persist ad fingerprints to disk and load them on subsequent runs
- prompt user to choose audio or video detection and scan a selected file

## Testing
- `dotnet test AdDetector/AdDetector.sln` *(fails: The current .NET SDK does not support targeting .NET 9.0)*

------
https://chatgpt.com/codex/tasks/task_e_689dc578fe748329b47a88c8af53868f